### PR TITLE
mkfs.fat: correct the disk signature to support reproducible-build

### DIFF
--- a/src/boot.c
+++ b/src/boot.c
@@ -32,6 +32,8 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <time.h>
+#include <errno.h>
+#include <ctype.h>
 
 #include "common.h"
 #include "fsck.fat.h"
@@ -736,6 +738,7 @@ static void write_volume_label(DOS_FS * fs, char *label)
 {
     time_t now;
     struct tm *mtime;
+    char *source_date_epoch = NULL;
     off_t offset;
     int created;
     DIR_ENT de;
@@ -751,8 +754,24 @@ static void write_volume_label(DOS_FS * fs, char *label)
     if (de.name[0] == 0xe5)
 	de.name[0] = 0x05;
 
-    now = time(NULL);
-    mtime = (now != (time_t)-1) ? localtime(&now) : NULL;
+    source_date_epoch = getenv("SOURCE_DATE_EPOCH");
+    if (source_date_epoch) {
+        char *tmp = NULL;
+        long long conversion = 0;
+        errno = 0;
+        conversion = strtoll(source_date_epoch, &tmp, 10);
+        now = conversion;
+        if (!isdigit(*source_date_epoch) || *tmp != '\0' || errno != 0
+                || (long long)now != conversion) {
+            die("SOURCE_DATE_EPOCH is too big or contains non-digits: \"%s\"",
+                source_date_epoch);
+        }
+        mtime = gmtime(&now);
+    } else {
+        now = time(NULL);
+        mtime = (now != (time_t)-1) ? localtime(&now) : NULL;
+    }
+
     if (mtime && mtime->tm_year >= 80 && mtime->tm_year <= 207) {
 	de.time = htole16((unsigned short)((mtime->tm_sec >> 1) +
 					   (mtime->tm_min << 5) +

--- a/src/common.c
+++ b/src/common.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <errno.h>
+#include <ctype.h>
 #include <wctype.h>
 #include <termios.h>
 #include <sys/time.h>
@@ -296,8 +297,20 @@ void check_atari(void)
 uint32_t generate_volume_id(void)
 {
     struct timeval now;
+    char *source_date_epoch = NULL;
 
-    if (gettimeofday(&now, NULL) != 0 || now.tv_sec == (time_t)-1 || now.tv_sec < 0) {
+    source_date_epoch = getenv("SOURCE_DATE_EPOCH");
+    if (source_date_epoch) {
+        char *tmp = NULL;
+        long long conversion = 0;
+        errno = 0;
+        conversion = strtoll(source_date_epoch, &tmp, 10);
+        if (!isdigit(*source_date_epoch) || *tmp != '\0' || errno != 0) {
+            die("SOURCE_DATE_EPOCH is too big or contains non-digits: \"%s\"",
+                source_date_epoch);
+        }
+        return (uint32_t)conversion;
+    } else if (gettimeofday(&now, NULL) != 0 || now.tv_sec == (time_t)-1 || now.tv_sec < 0) {
         srand(getpid());
         /* rand() returns int from [0,RAND_MAX], therefore only 31 bits */
         return (((uint32_t)(rand() & 0xFFFF)) << 16) | ((uint32_t)(rand() & 0xFFFF));

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1077,7 +1077,7 @@ static void setup_tables(void)
         }
 
         /* If is not available then generate random 32 bit disk signature */
-        if (invariant)
+        if (invariant || (getenv("SOURCE_DATE_EPOCH") && volume_id))
             disk_sig = volume_id;
         else if (!disk_sig)
             disk_sig = generate_volume_id();

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1077,7 +1077,7 @@ static void setup_tables(void)
         }
 
         /* If is not available then generate random 32 bit disk signature */
-        if (invariant || (getenv("SOURCE_DATE_EPOCH") && volume_id))
+        if (invariant || getenv("SOURCE_DATE_EPOCH"))
             disk_sig = volume_id;
         else if (!disk_sig)
             disk_sig = generate_volume_id();

--- a/src/mkfs.fat.c
+++ b/src/mkfs.fat.c
@@ -1457,7 +1457,6 @@ static void usage(const char *name, int exitval)
     fprintf(stderr, "  -v              Verbose execution\n");
     fprintf(stderr, "  --variant=TYPE  Select variant TYPE of filesystem (standard or Atari)\n");
     fprintf(stderr, "\n");
-    fprintf(stderr, "  --invariant     Use constants for randomly generated or time based values\n");
     fprintf(stderr, "  --offset=SECTOR Write the filesystem at a specific sector into the device file.\n");
     fprintf(stderr, "  --help          Show this help message and exit\n");
     exit(exitval);

--- a/tests/test-mkfs
+++ b/tests/test-mkfs
@@ -52,7 +52,7 @@ echo "Test $testname"
 rm -f "${testname}.out" "${testname}.refimg"
 
 xxd -r "${srcdir}/${testname}.xxd" "${testname}.refimg" || exit 99
-run_mkfs -C -v --invariant $ARGS "${testname}.out" $SIZE || exit 99
+(export SOURCE_DATE_EPOCH=1426325213; run_mkfs -C -v -i 0x1234abcd $ARGS "${testname}.out" $SIZE) || exit 99
 
 echo
 echo "Comparing..."


### PR DESCRIPTION
should not generate a random disk signature when "SOURCE_DATE_EPOCH"
and volume_id already exists, similar to using "--invariant" option

Signed-off-by: nguyen van hieu <hieu2.nguyenvan@toshiba.co.jp>